### PR TITLE
allow ">=" before the upper constraint

### DIFF
--- a/src/PackageInfo/VersionRange.elm
+++ b/src/PackageInfo/VersionRange.elm
@@ -69,7 +69,7 @@ enclosing version =
 
 splitRegex : Regex
 splitRegex =
-    Regex.regex "\\s*<=\\s*v\\s*<\\s*"
+    Regex.regex "\\s*<=\\s*v\\s*<=?\\s*"
 
 
 parseSegment : String -> Maybe String -> Result String Version

--- a/tests/PackageInfoTest.elm
+++ b/tests/PackageInfoTest.elm
@@ -22,7 +22,7 @@ elmPackageExample =
         "PackageInfo.VersionRange"
     ],
     "dependencies": {
-        "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "NoRedInk/elm-decode-pipeline": "3.0.0 <= v <= 4.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
- Whilst uncommon, the elm-package.json format allows a ">=" instead of
  a ">" before the upper constraint. A ">=" is only likely to exist
  in a hand-edited elm-package.json (for the purpose of pinning to
  a particular release)
- A ">=" has been added to one of the dependencies in the test case